### PR TITLE
Add pytest suite

### DIFF
--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -1,0 +1,21 @@
+import app
+
+
+def test_get_settings_endpoint(tmp_path):
+    app.config.set("archive_path", str(tmp_path))
+    client = app.app.test_client()
+    response = client.get('/api/settings')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, dict)
+    assert "archive_path" in data
+
+
+def test_validate_archive_path_endpoint(tmp_path):
+    client = app.app.test_client()
+    payload = {"path": str(tmp_path)}
+    response = client.post('/api/validate-archive-path', json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["valid"]
+    assert data["file_count"] == 0

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,30 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+
+from config_manager import ConfigManager
+
+
+def test_load_default_settings():
+    cfg = ConfigManager(config_file="nonexistent.json")
+    defaults = cfg._load_default_settings()
+    assert "archive_path" in defaults
+    assert defaults["theme_mode"] == "auto"
+
+
+def test_save_and_load_settings(tmp_path):
+    cfg_file = tmp_path / "settings.json"
+    cfg = ConfigManager(config_file=str(cfg_file))
+    cfg.set("archive_path", str(tmp_path))
+    assert cfg.save_settings()
+
+    new_cfg = ConfigManager(config_file=str(cfg_file))
+    assert new_cfg.get("archive_path") == str(tmp_path)
+
+
+def test_validation_errors(tmp_path):
+    cfg = ConfigManager(config_file=str(tmp_path / "settings.json"))
+    cfg.set("archive_path", str(tmp_path / "doesnotexist"))
+    errors = cfg.validate_settings()
+    assert "archive_path" in errors

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from app import ChatSearchEngine
+
+
+def create_file(dir_path, name, content):
+    path = Path(dir_path) / name
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    return path
+
+
+def test_extract_metadata(tmp_path):
+    file_path = create_file(tmp_path, 'sample.md', '---\naliases: Test\n---\nHello')
+    engine = ChatSearchEngine(str(tmp_path))
+    meta = engine.extract_metadata(file_path)
+    assert meta['title'] == 'Test'
+    assert meta['file_size'] > 0
+
+
+def test_search_in_content():
+    engine = ChatSearchEngine('.')
+    match, positions = engine.search_in_content('Hello world', 'Hello', mode='ALL')
+    assert match
+    assert positions
+
+
+def test_search(tmp_path):
+    create_file(tmp_path, 'a.md', '# Title: First\nHello world')
+    create_file(tmp_path, 'b.md', '# Title: Second\nAnother file')
+    engine = ChatSearchEngine(str(tmp_path))
+    query = {'terms': 'Hello', 'mode': 'ALL'}
+    results = engine.search(query)
+    assert len(results) == 1
+    assert results[0]['title'] == 'First'


### PR DESCRIPTION
## Summary
- add pytest tests for configuration manager
- add tests for search engine logic
- add basic API endpoint tests

## Testing
- `pip install -r /tmp/req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b72b75e20832e828fb811686d7c89