### PR TITLE
Fix title extraction and color validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,8 +142,11 @@ class ChatSearchEngine:
                 metadata = {}
                 body_content = content
             
-            # Extract title from content or filename
-            title = metadata.get('aliases', '')
+            # Extract title from metadata or fallbacks
+            # Some archives use `title` while others may use `aliases` for the
+            # conversation title. Try both before falling back to the content
+            # or filename.
+            title = metadata.get('title') or metadata.get('aliases', '')
             if not title:
                 # Try to find title in content
                 title_match = re.search(r'^# Title: (.+)$', body_content, re.MULTILINE)

--- a/config_manager.py
+++ b/config_manager.py
@@ -211,8 +211,12 @@ class ConfigManager:
         
         # Validate color format
         custom_color = self.get("custom_primary_color")
-        if custom_color and not custom_color.startswith("#") or len(custom_color) != 7:
-            errors["custom_primary_color"] = "Must be a valid hex color (e.g., #0d6efd)"
+        if custom_color and (
+            not custom_color.startswith("#") or len(custom_color) != 7
+        ):
+            errors["custom_primary_color"] = (
+                "Must be a valid hex color (e.g., #0d6efd)"
+            )
         
         return errors
     


### PR DESCRIPTION
## Summary
- pick correct key for YAML titles in search engine
- validate custom color with proper operator precedence

## Testing
- `pip install -r /tmp/req.txt`
- `python -m py_compile app.py config_manager.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_687b7255d240832e97301fdd05250bd5