### PR TITLE
Expand test suite

### DIFF
--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -1,3 +1,4 @@
+import json
 import app
 
 
@@ -19,3 +20,47 @@ def test_validate_archive_path_endpoint(tmp_path):
     data = response.get_json()
     assert data["valid"]
     assert data["file_count"] == 0
+
+
+def test_reset_settings_endpoint(tmp_path):
+    app.config.config_file = tmp_path / "settings.json"
+    client = app.app.test_client()
+    response = client.post('/api/settings/reset')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"]
+
+
+def test_export_settings_endpoint(tmp_path):
+    app.config.config_file = tmp_path / "settings.json"
+    app.config.set("archive_path", str(tmp_path))
+    client = app.app.test_client()
+    response = client.get('/api/settings/export')
+    assert response.status_code == 200
+    assert response.mimetype == 'application/json'
+
+
+def test_import_settings_endpoint(tmp_path):
+    app.config.config_file = tmp_path / "settings.json"
+    app.config.set("archive_path", str(tmp_path))
+    export_path = tmp_path / "export.json"
+    app.config.export_settings(str(export_path))
+
+    new_path = tmp_path / "new"
+    new_path.mkdir()
+    with open(export_path, 'r+', encoding='utf-8') as f:
+        data = json.load(f)
+        data['archive_path'] = str(new_path)
+        f.seek(0)
+        json.dump(data, f)
+        f.truncate()
+
+    client = app.app.test_client()
+    with open(export_path, 'rb') as f:
+        data = {'file': (f, 'settings.json')}
+        response = client.post('/api/settings/import', data=data, content_type='multipart/form-data')
+
+    assert response.status_code == 200
+    resp_data = response.get_json()
+    assert resp_data['success']
+    assert app.config.get('archive_path') == str(new_path)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -28,3 +28,31 @@ def test_validation_errors(tmp_path):
     cfg.set("archive_path", str(tmp_path / "doesnotexist"))
     errors = cfg.validate_settings()
     assert "archive_path" in errors
+
+
+def test_export_import_settings(tmp_path):
+    cfg_file = tmp_path / "settings.json"
+    cfg = ConfigManager(config_file=str(cfg_file))
+    cfg.set("archive_path", str(tmp_path))
+    cfg.save_settings()
+
+    export_file = tmp_path / "export.json"
+    assert cfg.export_settings(str(export_file))
+    assert export_file.exists()
+
+    with open(export_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+        assert "exported_at" in data
+
+    cfg.set("archive_path", "changed")
+    assert cfg.import_settings(str(export_file))
+    assert cfg.get("archive_path") == str(tmp_path)
+
+
+def test_get_theme_css_variables_custom():
+    cfg = ConfigManager(config_file="none.json")
+    cfg.set("theme", "custom")
+    cfg.set("custom_primary_color", "#ff0000")
+    vars = cfg.get_theme_css_variables()
+    assert vars["--accent-primary"] == "#ff0000"
+    assert "--sidebar-width" in vars

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -33,3 +33,40 @@ def test_search(tmp_path):
     results = engine.search(query)
     assert len(results) == 1
     assert results[0]['title'] == 'First'
+
+
+def test_search_folder_filters(tmp_path):
+    folder_a = tmp_path / 'a'
+    folder_a.mkdir()
+    folder_b = tmp_path / 'b'
+    folder_b.mkdir()
+
+    create_file(folder_a, 'file1.md', 'Hello world')
+    create_file(folder_b, 'file2.md', 'Hello world')
+
+    engine = ChatSearchEngine(str(tmp_path))
+
+    query_included = {
+        'terms': 'Hello',
+        'mode': 'ALL',
+        'includedFolders': ['a']
+    }
+    results_included = engine.search(query_included)
+    assert len(results_included) == 1
+    assert results_included[0]['path'].startswith('a/')
+
+    query_excluded = {
+        'terms': 'Hello',
+        'mode': 'ALL',
+        'excludedFolders': ['a']
+    }
+    results_excluded = engine.search(query_excluded)
+    assert len(results_excluded) == 1
+    assert results_excluded[0]['path'].startswith('b/')
+
+
+def test_search_in_content_any_case(tmp_path):
+    engine = ChatSearchEngine(str(tmp_path))
+    match, positions = engine.search_in_content('Foo Bar', 'bar', mode='ANY', case_sensitive=False)
+    assert match
+    assert positions


### PR DESCRIPTION
## Summary
- add tests for ConfigManager import/export and theme variables
- cover folder filtering logic in ChatSearchEngine
- exercise additional settings endpoints

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bad54460c832ea5433be5435d8861